### PR TITLE
feat(): integrate MapStruct for user data mapping and update account level handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,15 +54,17 @@ dependencies {
     implementation 'org.hibernate.orm:hibernate-envers:6.6.0.Final'
     //   Utility Library
     implementation 'org.apache.commons:commons-lang3:3.14.0'
+    //  mapping library
+    implementation 'org.mapstruct:mapstruct:1.6.3'
     //   Swagger/OpenAPI Documentation
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     //   Compile-Time Tools
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
     // Testing Dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/kh/com/blog/dto/response/UserInfoDTO.java
+++ b/src/main/java/kh/com/blog/dto/response/UserInfoDTO.java
@@ -1,5 +1,6 @@
 package kh.com.blog.dto.response;
 
+import kh.com.blog.common.enumeration.AccountLevel;
 import kh.com.blog.common.enumeration.Role;
 import lombok.Data;
 
@@ -10,5 +11,5 @@ public class UserInfoDTO {
 	private String email;
 	private Role role;
 	private Boolean isVerified;
-	private String accountLevel;
+	private AccountLevel accountLevel;
 }

--- a/src/main/java/kh/com/blog/mapper/UserMapper.java
+++ b/src/main/java/kh/com/blog/mapper/UserMapper.java
@@ -1,0 +1,19 @@
+package kh.com.blog.mapper;
+
+import kh.com.blog.dto.response.LoginResponseDTO;
+import kh.com.blog.dto.response.UserDetailResponseDTO;
+import kh.com.blog.entity.UserEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(
+		componentModel = MappingConstants.ComponentModel.SPRING,
+		nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+		unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface UserMapper {
+	UserDetailResponseDTO from(UserEntity userEntity);
+
+	LoginResponseDTO fromLogin(UserEntity userEntity);
+}

--- a/src/main/java/kh/com/blog/security/JwtService.java
+++ b/src/main/java/kh/com/blog/security/JwtService.java
@@ -3,6 +3,7 @@ package kh.com.blog.security;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import kh.com.blog.common.enumeration.AccountLevel;
 import kh.com.blog.common.enumeration.Role;
 import kh.com.blog.dto.response.UserInfoDTO;
 import lombok.extern.slf4j.Slf4j;
@@ -86,7 +87,7 @@ public class JwtService {
 		user.setEmail((String) claims.get(CLAIM_EMAIL));
 		user.setRole(Role.valueOf((String) claims.get(CLAIM_ROLE)));
 		user.setIsVerified((Boolean) claims.get(CLAIM_IS_VERIFIED));
-		user.setAccountLevel((String) claims.get(CLAIM_ACCOUNT_LEVEL));
+		user.setAccountLevel(AccountLevel.valueOf((String) claims.get(CLAIM_ACCOUNT_LEVEL)));
 
 		return user;
 	}

--- a/src/main/java/kh/com/blog/service/impl/UserServiceImpl.java
+++ b/src/main/java/kh/com/blog/service/impl/UserServiceImpl.java
@@ -1,7 +1,6 @@
 package kh.com.blog.service.impl;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import kh.com.blog.security.JwtService;
 import kh.com.blog.dto.request.LoginRequestDTO;
 import kh.com.blog.dto.request.RefreshTokenRequestDTO;
 import kh.com.blog.dto.request.RegisterRequestDTO;
@@ -11,7 +10,9 @@ import kh.com.blog.dto.response.UserDetailResponseDTO;
 import kh.com.blog.dto.response.UserInfoDTO;
 import kh.com.blog.entity.UserEntity;
 import kh.com.blog.exception.BusinessException;
+import kh.com.blog.mapper.UserMapper;
 import kh.com.blog.repository.UserRepository;
+import kh.com.blog.security.JwtService;
 import kh.com.blog.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,7 @@ public class UserServiceImpl implements UserService {
 	private final PasswordEncoder passwordEncoder;
 	private final ObjectMapper objectMapper;
 	private final JwtService jwtService;
+	private final UserMapper mapper;
 
 	@Override
 	public void registerUser(RegisterRequestDTO registerRequestDTO) {
@@ -78,7 +80,7 @@ public class UserServiceImpl implements UserService {
 			userInfoDTO.setEmail(userEntity.getEmail());
 			userInfoDTO.setRole(userEntity.getRole());
 			userInfoDTO.setIsVerified(userEntity.isVerified());
-			userInfoDTO.setAccountLevel(userEntity.getAccountLevel().name());
+			userInfoDTO.setAccountLevel(userEntity.getAccountLevel());
 			// generate JWT token
 			String token = jwtService.generateToken(userInfoDTO);
 			String refreshToken = jwtService.generateRefreshToken(userInfoDTO);
@@ -87,13 +89,7 @@ public class UserServiceImpl implements UserService {
 			// save the updated user entity
 			userRepository.save(userEntity);
 			// create and return LoginResponseDTO
-			LoginResponseDTO loginResponseDTO = new LoginResponseDTO();
-			loginResponseDTO.setId(userEntity.getId());
-			loginResponseDTO.setUsername(userEntity.getUsername());
-			loginResponseDTO.setBio(userEntity.getBio());
-			loginResponseDTO.setProfilePicture(userEntity.getProfilePicture());
-			loginResponseDTO.setCoverImage(userEntity.getCoverImage());
-			loginResponseDTO.setEmail(userEntity.getEmail());
+			LoginResponseDTO loginResponseDTO = mapper.fromLogin(userEntity);
 			loginResponseDTO.setAccessToken(token);
 			loginResponseDTO.setRefreshToken(refreshToken);
 			return loginResponseDTO;
@@ -130,8 +126,18 @@ public class UserServiceImpl implements UserService {
 	public UserDetailResponseDTO getCurrentUserDetail() {
 		try {
 			var authentication = SecurityContextHolder.getContext().getAuthentication();
-			log.info("(UserServiceImpl) getCurrentUserDetail(): Authentication: " + authentication);
-			return null;
+			String username = authentication.getPrincipal().toString();
+			if (ObjectUtils.isEmpty(username)) {
+				throw new BusinessException("User is not authenticated.");
+			}
+			// find the user by username
+			UserEntity userEntity = userRepository.findByUsername(username);
+			// if the user does not exist, throw BusinessException
+			if (ObjectUtils.isEmpty(userEntity)) {
+				throw new BusinessException("User not found.");
+			}
+			// convert UserEntity to UserDetailResponseDTO
+			return mapper.from(userEntity);
 		} catch (Exception e) {
 			log.error("(UserServiceImpl) getCurrentUserDetail(): Failed to get current user detail: " + e.getMessage());
 			throw new BusinessException(e.getMessage());


### PR DESCRIPTION
This pull request introduces several changes to improve type safety, streamline data mapping, and enhance the user service implementation. The most significant updates include replacing `String` with the `AccountLevel` enum for the `accountLevel` field, introducing a `UserMapper` interface for entity-to-DTO mapping, and enhancing the `UserServiceImpl` class with better exception handling and cleaner code.

### Type Safety Improvements:
* Replaced the `accountLevel` field in `UserInfoDTO` with the `AccountLevel` enum for improved type safety. Corresponding updates were made in `JwtService` and `UserServiceImpl`. (`[[1]](diffhunk://#diff-04cd5ce99af2d693baa65576be41025feb201d8c8292f6c9b20cff4401bdb62aL13-R14)`, `[[2]](diffhunk://#diff-6f4ccf35af641a70c5679942b73d5adc9e23788e3c817a2496a849b9989e26e1L89-R90)`, `[[3]](diffhunk://#diff-bac539146cfd0eeffc5310de102d1c7cd07edce4a73bb52596a93070c793b005L81-R83)`)

### Data Mapping Enhancements:
* Added a new `UserMapper` interface using MapStruct to handle conversions between `UserEntity` and DTOs (`LoginResponseDTO` and `UserDetailResponseDTO`). (`[src/main/java/kh/com/blog/mapper/UserMapper.javaR1-R19](diffhunk://#diff-ae927c0f046e55bef78bda6ee209754a51af1f21e38424aee4e3ace2fbd33e43R1-R19)`)
* Updated `UserServiceImpl` to use `UserMapper` for mapping `UserEntity` to `LoginResponseDTO` and `UserDetailResponseDTO`, simplifying the code. (`[[1]](diffhunk://#diff-bac539146cfd0eeffc5310de102d1c7cd07edce4a73bb52596a93070c793b005L90-R92)`, `[[2]](diffhunk://#diff-bac539146cfd0eeffc5310de102d1c7cd07edce4a73bb52596a93070c793b005L133-R140)`)

### User Service Enhancements:
* Implemented proper exception handling and validation in the `getCurrentUserDetail` method of `UserServiceImpl` to ensure robust error management. (`[src/main/java/kh/com/blog/service/impl/UserServiceImpl.javaL133-R140](diffhunk://#diff-bac539146cfd0eeffc5310de102d1c7cd07edce4a73bb52596a93070c793b005L133-R140)`)